### PR TITLE
Changed default feature extraction behaviour from trim -> pad

### DIFF
--- a/dasheng_model/feature_extraction_dasheng.py
+++ b/dasheng_model/feature_extraction_dasheng.py
@@ -81,8 +81,8 @@ class DashengFeatureExtractor(SequenceFeatureExtractor):
         self,
         x: Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]],
         sampling_rate: Optional[int] = None,
-        max_length: Optional[int] = 16000,
-        truncation: bool = True,
+        max_length: Optional[int] = None,
+        truncation: bool = False,
         return_tensors="pt",
     ) -> BatchFeature:
         r"""
@@ -133,7 +133,9 @@ class DashengFeatureExtractor(SequenceFeatureExtractor):
                 raise ValueError("torch.Tensor input must be a 1D or 2D.")
         elif isinstance(x, (list, tuple)):
             longest_length = max(x_.shape[0] for x_ in x)
-            if not truncation and max_length < longest_length:
+            if not truncation and max_length is not None and max_length < longest_length:
+                max_length = longest_length
+            if max_length is None:
                 max_length = longest_length
 
             if all(isinstance(x_, np.ndarray) for x_ in x):

--- a/dasheng_model/modeling_dasheng.py
+++ b/dasheng_model/modeling_dasheng.py
@@ -281,7 +281,7 @@ class AudioTransformerMAE_Encoder(nn.Module):
         **kwargs,
     ):
         super().__init__()
-        assert pooling in ("mean", "token")
+        assert pooling in ("mean", "token", "logit")
         self.pooling = pooling
         self.embed_dim = embed_dim
         self.patch_stride = patch_stride

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = '0.0.1'
 
 dependencies = [
     "einops",
+    "numpy==1.26.4",
     'torch==2.1.1',
     'torchaudio==2.1.1',
     'transformers==4.35.2'

--- a/tests/test_feature_extraction.py
+++ b/tests/test_feature_extraction.py
@@ -10,32 +10,38 @@ class TestDashengFeatureExtractor(unittest.TestCase):
 
     def test_extract_feature_from_pt_tensor(self):
         feature_extractor = DashengFeatureExtractor()
-        x = torch.randn(2, 16000)
+        x = torch.randn(2, 160000)
         y = feature_extractor(x)
-        assert y["input_values"].shape == (2, 64, 101)
+        assert y["input_values"].shape == (2, 64, 1001)
+
+    def test_extract_feature_from_pt_tensor_long(self):
+        feature_extractor = DashengFeatureExtractor()
+        x = torch.randn(3, 320000)
+        y = feature_extractor(x)
+        assert y["input_values"].shape == (3, 64, 2001)
 
     def test_extract_feature_from_np_array(self):
         feature_extractor = DashengFeatureExtractor()
-        x = np.random.rand(2, 16000)
+        x = np.random.rand(2, 160000)
         y = feature_extractor(x)
-        assert y["input_values"].shape == (2, 64, 101)
+        assert y["input_values"].shape == (2, 64, 1001)
 
     def test_extract_feature_from_list_of_pt_tensors(self):
         feature_extractor = DashengFeatureExtractor()
-        x = [torch.randn(16000), torch.randn(16000)]
+        x = [torch.randn(160000), torch.randn(160000)]
         y = feature_extractor(x)
-        assert y["input_values"].shape == (2, 64, 101)
+        assert y["input_values"].shape == (2, 64, 1001)
 
     def test_extract_feature_from_list_of_np_arrays(self):
         feature_extractor = DashengFeatureExtractor()
-        x = [np.random.rand(16000), np.random.rand(16000)]
+        x = [np.random.rand(160000), np.random.rand(160000)]
         y = feature_extractor(x)
-        assert y["input_values"].shape == (2, 64, 101)
+        assert y["input_values"].shape == (2, 64, 1001)
 
     def test_extract_feature_from_list_of_np_arrays_pad(self):
         feature_extractor = DashengFeatureExtractor()
-        x = [np.random.rand(10), np.random.rand(16000)]
-        y = feature_extractor(x, max_length=32000)
+        x = [np.random.rand(10), np.random.rand(160000)]
+        y = feature_extractor(x, max_length=32000, truncation=True)
         assert y["input_values"].shape == (2, 64, 201)
 
     def test_extract_feature_from_list_of_np_arrays_pad_trim(self):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -8,19 +8,37 @@ from dasheng_model.modeling_dasheng import DashengModel
 
 class TestInference(unittest.TestCase):
 
-    def test_dasheng_for_audio_classification(self):
+    def setUp(self):
         model_id = "mispeech/dasheng-base"
-        feature_extractor = DashengFeatureExtractor.from_pretrained(model_id)
-        model = DashengModel.from_pretrained(model_id)
+        self.feature_extractor = DashengFeatureExtractor.from_pretrained(model_id)
+        self.model = DashengModel.from_pretrained(model_id)
+        self.audio, self.sampling_rate = torchaudio.load("resources/JeD5V5aaaoI_931_932.wav")
 
-        audio, sampling_rate = torchaudio.load("resources/JeD5V5aaaoI_931_932.wav")
 
-        inputs = feature_extractor(audio, sampling_rate=sampling_rate, return_tensors="pt")
+    def test_dasheng_for_audio_classification(self):
+
+        inputs = self.feature_extractor(self.audio, sampling_rate=self.sampling_rate, return_tensors="pt")
         with torch.no_grad():
-            logits = model(**inputs).logits
+            logits = self.model(**inputs).logits
 
         assert logits.shape == (1, 768)
 
+    def test_dasheng_for_frame_level_feature_extraction(self):
+        inputs = self.feature_extractor(self.audio, sampling_rate=self.sampling_rate, return_tensors="pt")
+        with torch.no_grad():
+            frame_level_hiddens = self.model(**inputs).hidden_states
+
+        assert frame_level_hiddens.shape == (1, 25, 768)
+
+    def test_dasheng_for_frame_level_feature_extraction_long_padded(self):
+        #pad 10s
+        padded_audio = torch.nn.functional.pad(self.audio, (0, 160000))
+
+        inputs = self.feature_extractor(padded_audio, sampling_rate=self.sampling_rate, return_tensors="pt")
+        with torch.no_grad():
+            frame_level_hiddens = self.model(**inputs).hidden_states
+
+        assert frame_level_hiddens.shape == (1, 275, 768)
 
 if __name__ == "__main__":
     """


### PR DESCRIPTION
Before, the default behaviour of the Huggingface implementation was not very intuitive: By default Dasheng will trim only the first second of input and feed that into the model.
Many users might not pass the correct max_length into the feature extractor and don't see that they actually only feed 1s of audio into the model by default.

This PR changes this behaviour to pad the input and feed the entire tensor into the model.

Wrote tests to verify that the proposed change works for feature extraction. Also wrote tests for dasheng that the proposed method is functional.